### PR TITLE
Cargo.toml: Use `license` rather than `license-file` to avoid showing "Non-standard"`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ab-radix-trie"
 version = "0.2.1"
 edition = "2021"
-license-file = "LICENSE"
+license = "MIT"
 description = "A compressed radix trie implementation supporting matching rules"
 homepage = "https://github.com/avnerbarr/radix-trie"
 authors = ["Avner Barr <avner.barr@gmail.com>"]


### PR DESCRIPTION
`Cargo.toml` uses the `license-file` field to point to the `LICENSE`
file, which contains the MIT license. However, `license-file` is
normally used for custom licenses, and this leads crates.io to display
the license as "non-standard", which is misleading. Change it to
`license = "MIT"`, which makes crates.io show the license properly.
